### PR TITLE
refactor: Use Pydantic for DTOs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ urllib3==2.5.0
 Flask==3.1.1
 Flask-APScheduler==1.12.1
 gunicorn==23.0.0
+pydantic==2.8.2

--- a/src/scrapers/discount.py
+++ b/src/scrapers/discount.py
@@ -1,26 +1,13 @@
-from dataclasses import dataclass
+from pydantic import BaseModel
 from typing import Optional
 
 
-@dataclass
-class Discount:
+class Discount(BaseModel):
     product: str
     url: str
     image_url: Optional[str]
-    old_price: Optional[str]
-    new_price: Optional[str]
+    old_price: str
+    new_price: str
     category: Optional[str] = None
     site: Optional[str] = None
     discount_percent: Optional[str] = None
-
-    def to_dict(self):
-        return {
-            'product': self.product,
-            'url': self.url,
-            'image_url': self.image_url,
-            'old_price': self.old_price,
-            'new_price': self.new_price,
-            'category': self.category,
-            'site': self.site,
-            'discount_percent': self.discount_percent,
-        }

--- a/src/scrapers/discount_url.py
+++ b/src/scrapers/discount_url.py
@@ -3,11 +3,10 @@ DiscountUrl data transfer object.
 Represents a URL for a specific category that should be scraped.
 """
 
-from dataclasses import dataclass
+from pydantic import BaseModel
 
 
-@dataclass
-class DiscountUrl:
+class DiscountUrl(BaseModel):
     """Represents a URL for a specific category that should be scraped."""
     category: str
     url: str 

--- a/src/services/discount_service.py
+++ b/src/services/discount_service.py
@@ -62,7 +62,7 @@ def refresh_discounts_job():
     # Convert Discount objects to dictionaries for the cache
     discounts_dict = {}
     for category, discount_list in discounts.items():
-        discounts_dict[category] = [discount.to_dict() for discount in discount_list]
+        discounts_dict[category] = [discount.model_dump() for discount in discount_list]
     
     ALL_DISCOUNTS.clear()
     ALL_DISCOUNTS.update(discounts_dict)


### PR DESCRIPTION
This commit refactors the Discount and DiscountUrl classes to use Pydantic
for data validation, as requested in issue #24.

- Replaced @dataclass with pydantic.BaseModel for Discount and DiscountUrl.
- Added pydantic to requirements.txt.
- Replaced to_dict() with model_dump().
- Investigated optional fields and adjusted the model to reflect the
  actual usage in the scrapers.

Closes #24